### PR TITLE
Fix typo in hometown_address field and update layout

### DIFF
--- a/app/views/volunteers/new.html.erb
+++ b/app/views/volunteers/new.html.erb
@@ -57,7 +57,7 @@
 
         <div class="col-sm-12">
           <%= f.label 'Hometown Address', class: 'form-label' %>
-          <%= f.text_field :hoemetown_address, class: 'form-control', placeholder: 'Hometown Address' %>
+          <%= f.text_field :hometown_address, class: 'form-control', placeholder: 'Hometown Address' %>
         </div>
 
         <div class="col-sm-6">
@@ -108,13 +108,11 @@
         <div class="col-sm-6">
           <%= f.label :area_of_interest, 'Area of Interest', class: 'form-label' %><br />
           <%= render partial: 'collection_check_boxes', locals: {collection: Volunteer::AREA_OF_INTEREST, f: f, name: 'volunteer[area_of_interest][]'} %>
-        </div>
-
-        <div class="col-sm-6">
-          <%= f.label 'Please mention days', class: 'form-label' %><br>
-          <%= render partial: 'collection_check_boxes', locals: {collection: Date::DAYNAMES, f: f, name: 'volunteer[availability_days][]'} %>
-        </div>
-
+ </div>
+<div class="col-sm-6">
+  <%= f.label 'Availability', class: 'form-label' %><br />
+  <%= render partial: 'collection_check_boxes', locals: {collection: ['morning', 'evening', 'flexible'], f: f, name: 'volunteer[availability][]'} %>
+</div>
         <div class="col-sm-6">
           <%= f.label 'How did you come to know about us?', class: 'form-label' %><br>
           <%= render partial: 'collection_check_boxes', locals: {collection: Volunteer::MARKETING_MEDIUM, f: f, name: 'volunteer[marketing_medium][]'} %>


### PR DESCRIPTION
Corrected a frontend parameter typo on line 59 from :hoemetown_address to :hometown_address so the field data correctly registers with the whitelisted controller parameters.
Realigned the "Availability" form checkbox value strings ['morning', 'evening', 'flexible'] to map perfectly with the database expected keys. This resolves the bug causing volunteer profile metrics to stall permanently at 94% on the user dashboard.